### PR TITLE
fix: more cross-compilation fixes for loong64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+gcc-12 (12.3.0-17deepin8) unstable; urgency=medium
+
+  * Fix loong64 cross support markers - I erroneously used DEB_TARGET_ARCH to
+    match loong64 cross hosts, DEB_HOST_ARCH should have been used instead.
+  * Fix d_no_cross, which was missing a directive to disable D for cross
+    target builds.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Wed, 11 Sep 2024 16:20:30 +0800
+
 gcc-12 (12.3.0-17deepin7) unstable; urgency=medium
 
   * Disable loong64 cross support for go, gm2, and gnat.

--- a/debian/rules.defs
+++ b/debian/rules.defs
@@ -879,10 +879,8 @@ ada_no_snap	:= no
 #    ada_no_snap := yes
 #  endif
 #endif
-ifeq ($(DEB_CROSS),yes)
-  ifneq (,$(filter $(DEB_TARGET_ARCH),loong64))
-    ada_no_cross := yes
-  endif
+ifneq (,$(filter $(DEB_HOST_ARCH),loong64))
+  ada_no_cross := yes
 endif
 
 ifeq ($(with_dev),yes)
@@ -1036,10 +1034,8 @@ endif
 # Debian #969221
 go_no_archs += sh4
 
-ifeq ($(DEB_CROSS),yes)
-  ifneq (,$(filter $(DEB_TARGET_ARCH),loong64))
-    go_no_cross := yes
-  endif
+ifneq (,$(filter $(DEB_HOST_ARCH),loong64))
+  go_no_cross := yes
 endif
 
 ifneq ($(with_base_only),yes)
@@ -1111,6 +1107,9 @@ ifneq (,$(filter $(DEB_TARGET_GNU_SYSTEM),$(d_no_systems)))
 endif
 ifneq (,$(filter $(DEB_TARGET_ARCH),$(d_no_archs)))
   with_d := disabled for architecture $(DEB_TARGET_ARCH)
+endif
+ifeq ($(d_no_cross)-$(DEB_CROSS),yes-yes)
+  with_d := disabled for cross compiler package
 endif
 ifeq ($(d_no_snap)-$(single_package),yes-yes)
   with_d := disabled for snapshot build
@@ -1289,11 +1288,11 @@ ifneq ($(with_base_only),yes)
   endif
 endif
 m2_no_archs = i386 loong64 powerpc ppc64 sh4 kfreebsd-amd64 kfreebsd-i386 hurd-i386
-ifeq ($(DEB_CROSS),yes)
-  ifneq (,$(filter $(DEB_TARGET_ARCH),loong64))
-    m2_no_cross := yes
-  endif
+
+ifneq (,$(filter $(DEB_HOST_ARCH),loong64))
+  m2_no_cross := yes
 endif
+
 ifneq (,$(filter $(DEB_TARGET_ARCH),$(m2_no_archs)))
     with_m2 := disabled for cpu $(DEB_TARGET_ARCH)
 endif


### PR DESCRIPTION
- Fix loong64 cross support markers - I erroneously used DEB_TARGET_ARCH to match loong64 cross hosts, DEB_HOST_ARCH should have been used instead.
- Fix d_no_cross, which was missing a directive to disable D for cross target builds.