### PR TITLE
add patches for riscv64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+gcc-12 (12.3.0-17deepin12) unstable; urgency=medium
+
+  * Backports:
+    - [gcc r14-398] RISC-V: Eliminate SYNC memory models
+    - [gcc r14-399] RISC-V: Enforce Libatomic LR/SC SEQ_CST
+    - [gcc r14-400] RISC-V: Enforce subword atomic LR/SC SEQ_CST
+    - [gcc r14-401] RISC-V: Enforce atomic compare_exchange SEQ_CST
+    - [gcc r14-402] RISC-V: Add AMO release bits
+    - [gcc r14-403] RISC-V: Strengthen atomic stores
+    - [gcc r14-404] RISC-V: Eliminate AMO op fences
+    - [gcc r14-405] RISC-V: Weaken LR/SC pairs
+    - [gcc r14-406] RISC-V: Weaken mem_thread_fence
+    - [gcc r14-407] RISC-V: Weaken atomic loads
+    - [gcc r14-408] RISC-V: Table A.6 conformance tests
+
+ -- Chang Yang <yangchang@deepin.org>  Wed, 12 Mar 2025 14:59:47 +0800
+
 gcc-12 (12.3.0-17deepin11) unstable; urgency=medium
 
   * LoongArch: Fix errors on libsanitizer.

--- a/debian/patches/riscv64-atomic-fix.diff
+++ b/debian/patches/riscv64-atomic-fix.diff
@@ -1,0 +1,1002 @@
+From bdac4b47cbdac52c7082c02f54ed07197161cb4d Mon Sep 17 00:00:00 2001
+From: Monk Chiang <monk.chiang@sifive.com>
+Date: Fri, 21 Oct 2022 13:01:59 +0800
+Subject: [PATCH] RISC-V: Add type attribute for atomic instructions.
+
+gcc/ChangeLog:
+
+	* config/riscv/riscv.md: Add atomic type attribute.
+	* config/riscv/sync.md: Add atomic type for atomic instructions.
+---
+ gcc/config/riscv/riscv.md |  2 +-
+ gcc/config/riscv/sync.md  | 15 ++++++++++-----
+ 2 files changed, 11 insertions(+), 6 deletions(-)
+
+--- a/src/gcc/config/riscv/riscv.md
++++ b/src/gcc/config/riscv/riscv.md
+@@ -172,7 +172,7 @@
+ (define_attr "type"
+   "unknown,branch,jump,call,load,fpload,store,fpstore,
+    mtc,mfc,const,arith,logical,shift,slt,imul,idiv,move,fmove,fadd,fmul,
+-   fmadd,fdiv,fcmp,fcvt,fsqrt,multi,auipc,sfb_alu,nop,ghost,bitmanip,rotate"
++   atomic,fmadd,fdiv,fcmp,fcvt,fsqrt,multi,auipc,sfb_alu,nop,ghost,bitmanip,rotate"
+   (cond [(eq_attr "got" "load") (const_string "load")
+ 
+ 	 ;; If a doubleword move uses these expensive instructions,
+--- a/src/gcc/config/riscv/sync.md
++++ b/src/gcc/config/riscv/sync.md
+@@ -26,6 +26,7 @@
+   UNSPEC_SYNC_OLD_OP_SUBWORD
+   UNSPEC_SYNC_EXCHANGE
+   UNSPEC_SYNC_EXCHANGE_SUBWORD
++  UNSPEC_ATOMIC_LOAD
+   UNSPEC_ATOMIC_STORE
+   UNSPEC_MEMORY_BARRIER
+ ])
+@@ -49,18 +50,53 @@
+   DONE;
+ })
+ 
+-;; Until the RISC-V memory model (hence its mapping from C++) is finalized,
+-;; conservatively emit a full FENCE.
+ (define_insn "mem_thread_fence_1"
+   [(set (match_operand:BLK 0 "" "")
+ 	(unspec:BLK [(match_dup 0)] UNSPEC_MEMORY_BARRIER))
+    (match_operand:SI 1 "const_int_operand" "")] ;; model
+   ""
+-  "fence\tiorw,iorw")
++  {
++    enum memmodel model = (enum memmodel) INTVAL (operands[1]);
++    model = memmodel_base (model);
++    if (model == MEMMODEL_SEQ_CST)
++	return "fence\trw,rw";
++    else if (model == MEMMODEL_ACQ_REL)
++	return "fence.tso";
++    else if (model == MEMMODEL_ACQUIRE)
++	return "fence\tr,rw";
++    else if (model == MEMMODEL_RELEASE)
++	return "fence\trw,w";
++  }
++  [(set (attr "length") (const_int 4))])
+ 
+ ;; Atomic memory operations.
+ 
+-;; Implement atomic stores with amoswap.  Fall back to fences for atomic loads.
++(define_insn "atomic_load<mode>"
++  [(set (match_operand:GPR 0 "register_operand" "=r")
++    (unspec_volatile:GPR
++      [(match_operand:GPR 1 "memory_operand" "A")
++       (match_operand:SI 2 "const_int_operand")]      ;; model
++      UNSPEC_ATOMIC_LOAD))]
++  "TARGET_ATOMIC"
++  {
++    enum memmodel model = (enum memmodel) INTVAL (operands[2]);
++    model = memmodel_base (model);
++
++    if (model == MEMMODEL_SEQ_CST)
++      return "fence\trw,rw\;"
++	     "l<amo>\t%0,%1\;"
++	     "fence\tr,rw";
++    if (model == MEMMODEL_ACQUIRE)
++      return "l<amo>\t%0,%1\;"
++	     "fence\tr,rw";
++    else
++      return "l<amo>\t%0,%1";
++  }
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 12))])
++
++;; Implement atomic stores with conservative fences.
++;; This allows us to be compatible with the ISA manual Table A.6 and Table A.7.
+ (define_insn "atomic_store<mode>"
+   [(set (match_operand:GPR 0 "memory_operand" "=A")
+     (unspec_volatile:GPR
+@@ -68,8 +104,22 @@
+        (match_operand:SI 2 "const_int_operand")]      ;; model
+       UNSPEC_ATOMIC_STORE))]
+   "TARGET_ATOMIC"
+-  "%F2amoswap.<amo>%A2 zero,%z1,%0"
+-  [(set (attr "length") (const_int 8))])
++  {
++    enum memmodel model = (enum memmodel) INTVAL (operands[2]);
++    model = memmodel_base (model);
++
++    if (model == MEMMODEL_SEQ_CST)
++      return "fence\trw,w\;"
++	     "s<amo>\t%z1,%0\;"
++	     "fence\trw,rw";
++    if (model == MEMMODEL_RELEASE)
++      return "fence\trw,w\;"
++	     "s<amo>\t%z1,%0";
++    else
++      return "s<amo>\t%z1,%0";
++  }
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 12))])
+ 
+ (define_insn "atomic_<atomic_optab><mode>"
+   [(set (match_operand:GPR 0 "memory_operand" "+A")
+@@ -79,8 +129,9 @@
+ 	   (match_operand:SI 2 "const_int_operand")] ;; model
+ 	 UNSPEC_SYNC_OLD_OP))]
+   "TARGET_ATOMIC"
+-  "%F2amo<insn>.<amo>%A2 zero,%z1,%0"
+-  [(set (attr "length") (const_int 8))])
++  "amo<insn>.<amo>%A2\tzero,%z1,%0"
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 4))])
+ 
+ (define_insn "atomic_fetch_<atomic_optab><mode>"
+   [(set (match_operand:GPR 0 "register_operand" "=&r")
+@@ -92,8 +143,9 @@
+ 	   (match_operand:SI 3 "const_int_operand")] ;; model
+ 	 UNSPEC_SYNC_OLD_OP))]
+   "TARGET_ATOMIC"
+-  "%F3amo<insn>.<amo>%A3 %0,%z2,%1"
+-  [(set (attr "length") (const_int 8))])
++  "amo<insn>.<amo>%A3\t%0,%z2,%1"
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 4))])
+ 
+ (define_insn "subword_atomic_fetch_strong_<atomic_optab>"
+   [(set (match_operand:SI 0 "register_operand" "=&r")		   ;; old value at mem
+@@ -102,21 +154,22 @@
+ 	(unspec_volatile:SI
+ 	  [(any_atomic:SI (match_dup 1)
+ 		     (match_operand:SI 2 "register_operand" "rI")) ;; value for op
+-	   (match_operand:SI 3 "register_operand" "rI")]	   ;; mask
++	   (match_operand:SI 3 "const_int_operand")]		   ;; model
+ 	 UNSPEC_SYNC_OLD_OP_SUBWORD))
+-    (match_operand:SI 4 "register_operand" "rI")		   ;; not_mask
+-    (clobber (match_scratch:SI 5 "=&r"))			   ;; tmp_1
+-    (clobber (match_scratch:SI 6 "=&r"))]			   ;; tmp_2
++    (match_operand:SI 4 "register_operand" "rI")		   ;; mask
++    (match_operand:SI 5 "register_operand" "rI")		   ;; not_mask
++    (clobber (match_scratch:SI 6 "=&r"))			   ;; tmp_1
++    (clobber (match_scratch:SI 7 "=&r"))]			   ;; tmp_2
+   "TARGET_ATOMIC && TARGET_INLINE_SUBWORD_ATOMIC"
+   {
+     return "1:\;"
+-	   "lr.w.aq\t%0, %1\;"
+-	   "<insn>\t%5, %0, %2\;"
+-	   "and\t%5, %5, %3\;"
+-	   "and\t%6, %0, %4\;"
+-	   "or\t%6, %6, %5\;"
+-	   "sc.w.rl\t%5, %6, %1\;"
+-	   "bnez\t%5, 1b";
++	   "lr.w%I3\t%0, %1\;"
++	   "<insn>\t%6, %0, %2\;"
++	   "and\t%6, %6, %4\;"
++	   "and\t%7, %0, %5\;"
++	   "or\t%7, %7, %6\;"
++	   "sc.w%J3\t%6, %7, %1\;"
++	   "bnez\t%6, 1b";
+   }
+   [(set (attr "length") (const_int 28))])
+ 
+@@ -137,6 +190,7 @@
+   rtx old = gen_reg_rtx (SImode);
+   rtx mem = operands[1];
+   rtx value = operands[2];
++  rtx model = operands[3];
+   rtx aligned_mem = gen_reg_rtx (SImode);
+   rtx shift = gen_reg_rtx (SImode);
+   rtx mask = gen_reg_rtx (SImode);
+@@ -148,7 +202,7 @@
+   riscv_lshift_subword (<MODE>mode, value, shift, &shifted_value);
+ 
+   emit_insn (gen_subword_atomic_fetch_strong_nand (old, aligned_mem,
+-						   shifted_value,
++						   shifted_value, model,
+ 						   mask, not_mask));
+ 
+   emit_move_insn (old, gen_rtx_ASHIFTRT (SImode, old,
+@@ -166,22 +220,23 @@
+ 	(unspec_volatile:SI
+ 	  [(not:SI (and:SI (match_dup 1)
+ 			   (match_operand:SI 2 "register_operand" "rI"))) ;; value for op
+-	   (match_operand:SI 3 "register_operand" "rI")]		  ;; mask
++	   (match_operand:SI 3 "const_int_operand")]			  ;; mask
+ 	 UNSPEC_SYNC_OLD_OP_SUBWORD))
+-    (match_operand:SI 4 "register_operand" "rI")			  ;; not_mask
+-    (clobber (match_scratch:SI 5 "=&r"))				  ;; tmp_1
+-    (clobber (match_scratch:SI 6 "=&r"))]				  ;; tmp_2
++    (match_operand:SI 4 "register_operand" "rI")			  ;; mask
++    (match_operand:SI 5 "register_operand" "rI")			  ;; not_mask
++    (clobber (match_scratch:SI 6 "=&r"))				  ;; tmp_1
++    (clobber (match_scratch:SI 7 "=&r"))]				  ;; tmp_2
+   "TARGET_ATOMIC && TARGET_INLINE_SUBWORD_ATOMIC"
+   {
+     return "1:\;"
+-	   "lr.w.aq\t%0, %1\;"
+-	   "and\t%5, %0, %2\;"
+-	   "not\t%5, %5\;"
+-	   "and\t%5, %5, %3\;"
+-	   "and\t%6, %0, %4\;"
+-	   "or\t%6, %6, %5\;"
+-	   "sc.w.rl\t%5, %6, %1\;"
+-	   "bnez\t%5, 1b";
++	   "lr.w%I3\t%0, %1\;"
++	   "and\t%6, %0, %2\;"
++	   "not\t%6, %6\;"
++	   "and\t%6, %6, %4\;"
++	   "and\t%7, %0, %5\;"
++	   "or\t%7, %7, %6\;"
++	   "sc.w%J3\t%6, %7, %1\;"
++	   "bnez\t%6, 1b";
+   }
+   [(set (attr "length") (const_int 32))])
+ 
+@@ -202,6 +257,7 @@
+   rtx old = gen_reg_rtx (SImode);
+   rtx mem = operands[1];
+   rtx value = operands[2];
++  rtx model = operands[3];
+   rtx aligned_mem = gen_reg_rtx (SImode);
+   rtx shift = gen_reg_rtx (SImode);
+   rtx mask = gen_reg_rtx (SImode);
+@@ -214,7 +270,8 @@
+ 
+   emit_insn (gen_subword_atomic_fetch_strong_<atomic_optab> (old, aligned_mem,
+ 							     shifted_value,
+-							     mask, not_mask));
++							     model, mask,
++							     not_mask));
+ 
+   emit_move_insn (old, gen_rtx_ASHIFTRT (SImode, old,
+ 					 gen_lowpart (QImode, shift)));
+@@ -233,8 +290,9 @@
+    (set (match_dup 1)
+ 	(match_operand:GPR 2 "register_operand" "0"))]
+   "TARGET_ATOMIC"
+-  "%F3amoswap.<amo>%A3 %0,%z2,%1"
+-  [(set (attr "length") (const_int 8))])
++  "amoswap.<amo>%A3\t%0,%z2,%1"
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 4))])
+ 
+ (define_expand "atomic_exchange<mode>"
+   [(match_operand:SHORT 0 "register_operand") ;; old value at mem
+@@ -246,6 +304,7 @@
+   rtx old = gen_reg_rtx (SImode);
+   rtx mem = operands[1];
+   rtx value = operands[2];
++  rtx model = operands[3];
+   rtx aligned_mem = gen_reg_rtx (SImode);
+   rtx shift = gen_reg_rtx (SImode);
+   rtx mask = gen_reg_rtx (SImode);
+@@ -257,7 +316,8 @@
+   riscv_lshift_subword (<MODE>mode, value, shift, &shifted_value);
+ 
+   emit_insn (gen_subword_atomic_exchange_strong (old, aligned_mem,
+-						 shifted_value, not_mask));
++						 shifted_value, model,
++						 not_mask));
+ 
+   emit_move_insn (old, gen_rtx_ASHIFTRT (SImode, old,
+ 					 gen_lowpart (QImode, shift)));
+@@ -271,18 +331,19 @@
+ 	(match_operand:SI 1 "memory_operand" "+A"))	 ;; mem location
+    (set (match_dup 1)
+ 	(unspec_volatile:SI
+-	  [(match_operand:SI 2 "reg_or_0_operand" "rI")  ;; value
+-	   (match_operand:SI 3 "reg_or_0_operand" "rI")] ;; not_mask
++	  [(match_operand:SI 2 "reg_or_0_operand" "rI")	 ;; value
++	   (match_operand:SI 3 "const_int_operand")]	 ;; model
+       UNSPEC_SYNC_EXCHANGE_SUBWORD))
+-    (clobber (match_scratch:SI 4 "=&r"))]		 ;; tmp_1
++    (match_operand:SI 4 "reg_or_0_operand" "rI")	 ;; not_mask
++    (clobber (match_scratch:SI 5 "=&r"))]		 ;; tmp_1
+   "TARGET_ATOMIC && TARGET_INLINE_SUBWORD_ATOMIC"
+   {
+     return "1:\;"
+-	   "lr.w.aq\t%0, %1\;"
+-	   "and\t%4, %0, %3\;"
+-	   "or\t%4, %4, %2\;"
+-	   "sc.w.rl\t%4, %4, %1\;"
+-	   "bnez\t%4, 1b";
++	   "lr.w%I3\t%0, %1\;"
++	   "and\t%5, %0, %4\;"
++	   "or\t%5, %5, %2\;"
++	   "sc.w%J3\t%5, %5, %1\;"
++	   "bnez\t%5, 1b";
+   }
+   [(set (attr "length") (const_int 20))])
+ 
+@@ -297,8 +358,21 @@
+ 	 UNSPEC_COMPARE_AND_SWAP))
+    (clobber (match_scratch:GPR 6 "=&r"))]
+   "TARGET_ATOMIC"
+-  "%F5 1: lr.<amo>%A5 %0,%1; bne %0,%z2,1f; sc.<amo>%A4 %6,%z3,%1; bnez %6,1b; 1:"
+-  [(set (attr "length") (const_int 20))])
++  {
++    enum memmodel model_success = (enum memmodel) INTVAL (operands[4]);
++    enum memmodel model_failure = (enum memmodel) INTVAL (operands[5]);
++    /* Find the union of the two memory models so we can satisfy both success
++       and failure memory models.  */
++    operands[5] = GEN_INT (riscv_union_memmodels (model_success, model_failure));
++    return "1:\;"
++	   "lr.<amo>%I5\t%0,%1\;"
++	   "bne\t%0,%z2,1f\;"
++	   "sc.<amo>%J5\t%6,%z3,%1\;"
++	   "bnez\t%6,1b\;"
++	   "1:";
++  }
++  [(set_attr "type" "atomic")
++   (set (attr "length") (const_int 16))])
+ 
+ (define_expand "atomic_compare_and_swap<mode>"
+   [(match_operand:SI 0 "register_operand" "")   ;; bool output
+@@ -417,9 +491,15 @@
+   emit_move_insn (shifted_o, gen_rtx_AND (SImode, shifted_o, mask));
+   emit_move_insn (shifted_n, gen_rtx_AND (SImode, shifted_n, mask));
+ 
++  enum memmodel model_success = (enum memmodel) INTVAL (operands[4]);
++  enum memmodel model_failure = (enum memmodel) INTVAL (operands[5]);
++  /* Find the union of the two memory models so we can satisfy both success
++     and failure memory models.  */
++  rtx model = GEN_INT (riscv_union_memmodels (model_success, model_failure));
++
+   emit_insn (gen_subword_atomic_cas_strong (old, aligned_mem,
+ 					    shifted_o, shifted_n,
+-					    mask, not_mask));
++					    model, mask, not_mask));
+ 
+   emit_move_insn (old, gen_rtx_ASHIFTRT (SImode, old,
+ 					 gen_lowpart (QImode, shift)));
+@@ -436,19 +516,20 @@
+ 	(unspec_volatile:SI [(match_operand:SI 2 "reg_or_0_operand" "rJ")  ;; expected value
+ 			     (match_operand:SI 3 "reg_or_0_operand" "rJ")] ;; desired value
+ 	 UNSPEC_COMPARE_AND_SWAP_SUBWORD))
+-	(match_operand:SI 4 "register_operand" "rI")			   ;; mask
+-	(match_operand:SI 5 "register_operand" "rI")			   ;; not_mask
+-	(clobber (match_scratch:SI 6 "=&r"))]				   ;; tmp_1
++	(match_operand:SI 4 "const_int_operand")			   ;; model
++	(match_operand:SI 5 "register_operand" "rI")			   ;; mask
++	(match_operand:SI 6 "register_operand" "rI")			   ;; not_mask
++	(clobber (match_scratch:SI 7 "=&r"))]				   ;; tmp_1
+   "TARGET_ATOMIC && TARGET_INLINE_SUBWORD_ATOMIC"
+   {
+     return "1:\;"
+-	   "lr.w.aq\t%0, %1\;"
+-	   "and\t%6, %0, %4\;"
+-	   "bne\t%6, %z2, 1f\;"
+-	   "and\t%6, %0, %5\;"
+-	   "or\t%6, %6, %3\;"
+-	   "sc.w.rl\t%6, %6, %1\;"
+-	   "bnez\t%6, 1b\;"
++	   "lr.w%I4\t%0, %1\;"
++	   "and\t%7, %0, %5\;"
++	   "bne\t%7, %z2, 1f\;"
++	   "and\t%7, %0, %6\;"
++	   "or\t%7, %7, %3\;"
++	   "sc.w%J4\t%7, %7, %1\;"
++	   "bnez\t%7, 1b\;"
+ 	   "1:";
+   }
+   [(set (attr "length") (const_int 28))])
+--- a/src/gcc/config/riscv/riscv.cc
++++ b/src/gcc/config/riscv/riscv.cc
+@@ -3577,6 +3577,36 @@
+   fputc (')', file);
+ }
+ 
++/* Return the memory model that encapuslates both given models.  */
++
++enum memmodel
++riscv_union_memmodels (enum memmodel model1, enum memmodel model2)
++{
++  model1 = memmodel_base (model1);
++  model2 = memmodel_base (model2);
++
++  enum memmodel weaker = model1 <= model2 ? model1: model2;
++  enum memmodel stronger = model1 > model2 ? model1: model2;
++
++  switch (stronger)
++    {
++      case MEMMODEL_SEQ_CST:
++      case MEMMODEL_ACQ_REL:
++	return stronger;
++      case MEMMODEL_RELEASE:
++	if (weaker == MEMMODEL_ACQUIRE || weaker == MEMMODEL_CONSUME)
++	  return MEMMODEL_ACQ_REL;
++	else
++	  return stronger;
++      case MEMMODEL_ACQUIRE:
++      case MEMMODEL_CONSUME:
++      case MEMMODEL_RELAXED:
++	return stronger;
++      default:
++	gcc_unreachable ();
++    }
++}
++
+ /* Return true if the .AQ suffix should be added to an AMO to implement the
+    acquire portion of memory model MODEL.  */
+ 
+@@ -3587,14 +3617,11 @@
+     {
+       case MEMMODEL_ACQ_REL:
+       case MEMMODEL_SEQ_CST:
+-      case MEMMODEL_SYNC_SEQ_CST:
+       case MEMMODEL_ACQUIRE:
+       case MEMMODEL_CONSUME:
+-      case MEMMODEL_SYNC_ACQUIRE:
+ 	return true;
+ 
+       case MEMMODEL_RELEASE:
+-      case MEMMODEL_SYNC_RELEASE:
+       case MEMMODEL_RELAXED:
+ 	return false;
+ 
+@@ -3603,24 +3630,21 @@
+     }
+ }
+ 
+-/* Return true if a FENCE should be emitted to before a memory access to
+-   implement the release portion of memory model MODEL.  */
++/* Return true if the .RL suffix should be added to an AMO to implement the
++   release portion of memory model MODEL.  */
+ 
+ static bool
+-riscv_memmodel_needs_release_fence (enum memmodel model)
++riscv_memmodel_needs_amo_release (enum memmodel model)
+ {
+   switch (model)
+     {
+       case MEMMODEL_ACQ_REL:
+       case MEMMODEL_SEQ_CST:
+-      case MEMMODEL_SYNC_SEQ_CST:
+       case MEMMODEL_RELEASE:
+-      case MEMMODEL_SYNC_RELEASE:
+ 	return true;
+ 
+       case MEMMODEL_ACQUIRE:
+       case MEMMODEL_CONSUME:
+-      case MEMMODEL_SYNC_ACQUIRE:
+       case MEMMODEL_RELAXED:
+ 	return false;
+ 
+@@ -3636,7 +3660,8 @@
+    'R'	Print the low-part relocation associated with OP.
+    'C'	Print the integer branch condition for comparison OP.
+    'A'	Print the atomic operation suffix for memory model OP.
+-   'F'	Print a FENCE if the memory model requires a release.
++   'I'	Print the LR suffix for memory model OP.
++   'J'	Print the SC suffix for memory model OP.
+    'z'	Print x0 if OP is zero, otherwise print OP normally.
+    'i'	Print i if the operand is not a register.
+    'S'	Print shift-index of single-bit mask OP.
+@@ -3647,6 +3672,7 @@
+ {
+   machine_mode mode = GET_MODE (op);
+   enum rtx_code code = GET_CODE (op);
++  const enum memmodel model = memmodel_base (INTVAL (op));
+ 
+   switch (letter)
+     {
+@@ -3666,13 +3692,25 @@
+       break;
+ 
+     case 'A':
+-      if (riscv_memmodel_needs_amo_acquire ((enum memmodel) INTVAL (op)))
++      if (riscv_memmodel_needs_amo_acquire (model)
++	  && riscv_memmodel_needs_amo_release (model))
++	fputs (".aqrl", file);
++      else if (riscv_memmodel_needs_amo_acquire (model))
++	fputs (".aq", file);
++      else if (riscv_memmodel_needs_amo_release (model))
++	fputs (".rl", file);
++      break;
++
++    case 'I':
++      if (model == MEMMODEL_SEQ_CST)
++	fputs (".aqrl", file);
++      else if (riscv_memmodel_needs_amo_acquire (model))
+ 	fputs (".aq", file);
+       break;
+ 
+-    case 'F':
+-      if (riscv_memmodel_needs_release_fence ((enum memmodel) INTVAL (op)))
+-	fputs ("fence iorw,ow; ", file);
++    case 'J':
++      if (riscv_memmodel_needs_amo_release (model))
++	fputs (".rl", file);
+       break;
+ 
+     case 'i':
+--- a/src/libgcc/config/riscv/atomic.c
++++ b/src/libgcc/config/riscv/atomic.c
+@@ -41,7 +41,7 @@
+     unsigned old, tmp1, tmp2;						\
+ 									\
+     asm volatile ("1:\n\t"						\
+-		  "lr.w.aq %[old], %[mem]\n\t"				\
++		  "lr.w.aqrl %[old], %[mem]\n\t"			\
+ 		  #insn " %[tmp1], %[old], %[value]\n\t"		\
+ 		  invert						\
+ 		  "and %[tmp1], %[tmp1], %[mask]\n\t"			\
+@@ -75,7 +75,7 @@
+     unsigned old, tmp1;							\
+ 									\
+     asm volatile ("1:\n\t"						\
+-		  "lr.w.aq %[old], %[mem]\n\t"				\
++		  "lr.w.aqrl %[old], %[mem]\n\t"			\
+ 		  "and %[tmp1], %[old], %[mask]\n\t"			\
+ 		  "bne %[tmp1], %[o], 1f\n\t"				\
+ 		  "and %[tmp1], %[old], %[not_mask]\n\t"		\
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/pr89835.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that relaxed atomic stores use simple store instuctions.  */
++/* { dg-final { scan-assembler-not "amoswap" } } */
++
++void
++foo(int bar, int baz)
++{
++  __atomic_store_n(&bar, baz, __ATOMIC_RELAXED);
++}
+--- a/src/gcc/config/riscv/riscv-protos.h
++++ b/src/gcc/config/riscv/riscv-protos.h
+@@ -22,6 +22,8 @@
+ #ifndef GCC_RISCV_PROTOS_H
+ #define GCC_RISCV_PROTOS_H
+ 
++#include "memmodel.h"
++
+ /* Symbol types we understand.  The order of this list must match that of
+    the unspec enum in riscv.md, subsequent to UNSPEC_ADDRESS_FIRST.  */
+ enum riscv_symbol_type {
+@@ -76,6 +78,7 @@
+ extern bool riscv_gpr_save_operation_p (rtx);
+ extern void riscv_subword_address (rtx, rtx *, rtx *, rtx *, rtx *);
+ extern void riscv_lshift_subword (machine_mode, rtx, rtx, rtx *);
++extern enum memmodel riscv_union_memmodels (enum memmodel, enum memmodel);
+ 
+ /* Routines implemented in riscv-c.cc.  */
+ void riscv_cpu_cpp_builtins (cpp_reader *);
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-amo-add-1.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	amoadd\.w\tzero,a1,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-amo-add-2.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	amoadd\.w\.aq\tzero,a1,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-amo-add-3.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	amoadd\.w\.rl\tzero,a1,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_RELEASE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-amo-add-4.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	amoadd\.w\.aqrl\tzero,a1,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_ACQ_REL);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-amo-add-5.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	amoadd\.w\.aqrl\tzero,a1,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_SEQ_CST);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-1.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-2.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aq\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_CONSUME, __ATOMIC_CONSUME);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-3.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aq\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-4.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-5.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aqrl\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-6.c
+@@ -0,0 +1,10 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* Mixed mappings need to be unioned.  */
++/* { dg-final { scan-assembler-times "lr.w.aq\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-compare-exchange-7.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that compare exchange mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aqrl\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (int bar, int baz, int qux)
++{
++  __atomic_compare_exchange_n(&bar, &baz, qux, 1, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-fence-1.c
+@@ -0,0 +1,14 @@
++/* { dg-do compile } */
++/* Verify that fence mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	ret
++*/
++void foo()
++{
++  __atomic_thread_fence(__ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-fence-2.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that fence mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	fence\tr,rw
++**	ret
++*/
++void foo()
++{
++  __atomic_thread_fence(__ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-fence-3.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that fence mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	fence\trw,w
++**	ret
++*/
++void foo()
++{
++  __atomic_thread_fence(__ATOMIC_RELEASE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-fence-4.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that fence mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	fence\.tso
++**	ret
++*/
++void foo()
++{
++  __atomic_thread_fence(__ATOMIC_ACQ_REL);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-fence-5.c
+@@ -0,0 +1,15 @@
++/* { dg-do compile } */
++/* Verify that fence mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	fence\trw,rw
++**	ret
++*/
++void foo()
++{
++  __atomic_thread_fence(__ATOMIC_SEQ_CST);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-load-1.c
+@@ -0,0 +1,16 @@
++/* { dg-do compile } */
++/* Verify that load mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	lw\ta[0-9]+,0\(a0\)
++**	sw\ta[0-9]+,0\(a1\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_load(bar, baz, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-load-2.c
+@@ -0,0 +1,17 @@
++/* { dg-do compile } */
++/* Verify that load mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	lw\ta[0-9]+,0\(a0\)
++**	fence\tr,rw
++**	sw\ta[0-9]+,0\(a1\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_load(bar, baz, __ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-load-3.c
+@@ -0,0 +1,18 @@
++/* { dg-do compile } */
++/* Verify that load mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	fence\trw,rw
++**	lw\ta[0-9]+,0\(a0\)
++**	fence\tr,rw
++**	sw\ta[0-9]+,0\(a1\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_load(bar, baz, __ATOMIC_SEQ_CST);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-store-1.c
+@@ -0,0 +1,16 @@
++/* { dg-do compile } */
++/* Verify that store mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	lw\ta[0-9]+,0\(a1\)
++**	sw\ta[0-9]+,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_store(bar, baz, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-store-2.c
+@@ -0,0 +1,17 @@
++/* { dg-do compile } */
++/* Verify that store mappings match Table A.6's recommended mapping.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	lw\ta[0-9]+,0\(a1\)
++**	fence\trw,w
++**	sw\ta[0-9]+,0\(a0\)
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_store(bar, baz, __ATOMIC_RELEASE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-store-compat-3.c
+@@ -0,0 +1,18 @@
++/* { dg-do compile } */
++/* Verify that store mapping are compatible with Table A.6 & A.7.  */
++/* { dg-options "-O3" } */
++/* { dg-skip-if "" { *-*-* } { "-g" "-flto"} } */
++/* { dg-final { check-function-bodies "**" "" } } */
++
++/*
++** foo:
++**	lw\ta[0-9]+,0\(a1\)
++**	fence\trw,w
++**	sw\ta[0-9]+,0\(a0\)
++**	fence\trw,rw
++**	ret
++*/
++void foo (int* bar, int* baz)
++{
++  __atomic_store(bar, baz, __ATOMIC_SEQ_CST);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-subword-amo-add-1.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that subword atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w\t" 1 } } */
++
++void foo (short* bar, short* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_RELAXED);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-subword-amo-add-2.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that subword atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aq\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w\t" 1 } } */
++
++void foo (short* bar, short* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_ACQUIRE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-subword-amo-add-3.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that subword atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (short* bar, short* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_RELEASE);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-subword-amo-add-4.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that subword atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aq\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (short* bar, short* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_ACQ_REL);
++}
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/amo-table-a-6-subword-amo-add-5.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* Verify that subword atomic op mappings match Table A.6's recommended mapping.  */
++/* { dg-final { scan-assembler-times "lr.w.aqrl\t" 1 } } */
++/* { dg-final { scan-assembler-times "sc.w.rl\t" 1 } } */
++
++void foo (short* bar, short* baz)
++{
++  __atomic_add_fetch(bar, baz, __ATOMIC_SEQ_CST);
++}

--- a/debian/rules.patch
+++ b/debian/rules.patch
@@ -572,6 +572,7 @@ debian_patches += \
 
 # RISCV backport.
 debian_patches += riscv64-inline-subword-atomic
+debian_patches += riscv64-atomic-fix
 
 series_stamp = $(stampdir)/02-series-stamp
 series: $(series_stamp)


### PR DESCRIPTION
fix bug in gcc 12:
```
malloc(): unaligned fastbin chunk detected
```

## Summary by Sourcery

Bug Fixes:
- Fixes a bug in gcc 12 that causes 'malloc(): unaligned fastbin chunk detected'