### PR TITLE
feat: Adjust generic loop alignment from 16:11:8 to 16 for Intel proc…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gcc-12 (12.3.0-17deepin13) unstable; urgency=medium
+
+  * Backport: Adjust generic loop alignment from 16:11:8 to 16 for Intel processors
+
+ -- xiangzelong <xiangzelong@deepin.org>  Wed, 04 Jun 2025 13:35:12 +0800
+
 gcc-12 (12.3.0-17deepin12) unstable; urgency=medium
 
   * Backports:

--- a/debian/patches/Adjust-generic-loop-alignment-from-16-11-8-to-16-for-Intel.diff
+++ b/debian/patches/Adjust-generic-loop-alignment-from-16-11-8-to-16-for-Intel.diff
@@ -1,0 +1,35 @@
+diff --git a/src/gcc/config/i386/x86-tune-costs.h b/src/gcc/config/i386/x86-tune-costs.h
+index f105d57ca..098a45fd8 100644
+From: xzl <xiangzelong@deepin.org>
+From: Haochen Jiang <haochen.jiang@intel.com>
+Date: Wed, 4 Jun 2025 11:23:03 +0800
+Subject: [PATCH 1/1] Adjust generic loop alignment from 16:11:8 to 16 for
+ Intel processors
+
+Previously, we use 16:11:8 in generic tune for Intel processors, which
+lead to cross cache line issue and result in some random performance
+penalty in benchmarks with small loops commit to commit.
+
+After changing to always aligning to 16 bytes, it will somehow solve
+the issue.
+
+gcc/ChangeLog:
+
+	* config/i386/x86-tune-costs.h (generic_cost): Change from
+	16:11:8 to 16.
+--- a/src/gcc/config/i386/x86-tune-costs.h
++++ b/src/gcc/config/i386/x86-tune-costs.h
+@@ -3335,7 +3335,7 @@ struct processor_costs generic_cost = {
+   generic_memset,
+   COSTS_N_INSNS (4),			/* cond_taken_branch_cost.  */
+   COSTS_N_INSNS (2),			/* cond_not_taken_branch_cost.  */
+-  "16:11:8",				/* Loop alignment.  */
++  "16",				/* Loop alignment.  */
+   "16:11:8",				/* Jump alignment.  */
+   "0:0:8",				/* Label alignment.  */
+   "16",					/* Func alignment.  */
+@@ -3466,4 +3466,3 @@ struct processor_costs core_cost = {
+   "0:0:8",				/* Label alignment.  */
+   "16",					/* Func alignment.  */
+ };
+-

--- a/debian/rules.patch
+++ b/debian/rules.patch
@@ -71,6 +71,7 @@ debian_patches += \
 	asan-allocator-base \
 	gcc-vhdl \
 	pr114533 \
+  Adjust-generic-loop-alignment-from-16-11-8-to-16-for-Intel\
 
 # with glibc (>= 2.31)
 ifeq (,$(filter $(distrelease),wheezy jessie stretch buster precise xenial bionic))


### PR DESCRIPTION
…essors

Log: Backport from https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=00ed5424b1d4dcccfa187f55205521826794898c

## Summary by Sourcery

Backport upstream optimization to adjust generic loop alignment for Intel processors and integrate it into the Debian packaging.

Enhancements:
- Adjust generic loop alignment from 16:11:8 to 16 for Intel processors to match upstream GCC optimization.

Build:
- Add new Debian patch file to apply the loop-alignment adjustment.
- Update debian/changelog and rules to include and apply the backported patch.