### PR TITLE
LoongArch: fix gcc_except_table

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gcc-12 (12.3.0-17deepin13) unstable; urgency=medium
+
+  * LoongArch: fix gcc_except_table
+
+ -- Peng Fan <fanpeng@loongson.cn>  Sat, 07 Jun 2025 02:41:59 +0000
+
 gcc-12 (12.3.0-17deepin12) unstable; urgency=medium
 
   * Backports:

--- a/debian/patches/loong64/except-Don-t-use-the-cached-value-of-the-gcc_except_.diff
+++ b/debian/patches/loong64/except-Don-t-use-the-cached-value-of-the-gcc_except_.diff
@@ -1,0 +1,43 @@
+diff --git a/src/gcc/except.cc b/src/gcc/except.cc
+index b94de4255..8714c1be8 100644
+--- a/src/gcc/except.cc
++++ b/src/gcc/except.cc
+@@ -2906,7 +2906,14 @@ switch_to_exception_section (const char * ARG_UNUSED (fnname))
+ {
+   section *s;
+ 
+-  if (exception_section)
++  if (exception_section
++  /* Don't use the cached section for comdat if it will be different. */
++#ifdef HAVE_LD_EH_GC_SECTIONS
++      && !(targetm_common.have_named_sections
++	   && DECL_COMDAT_GROUP (current_function_decl)
++	   && HAVE_COMDAT_GROUP)
++#endif
++     )
+     s = exception_section;
+   else
+     {
+diff --git a/src/gcc/testsuite/g++.dg/eh/pr119507.C b/src/gcc/testsuite/g++.dg/eh/pr119507.C
+new file mode 100644
+index 000000000..50afa75a4
+--- /dev/null
++++ b/src/gcc/testsuite/g++.dg/eh/pr119507.C
+@@ -0,0 +1,17 @@
++// { dg-do compile { target comdat_group } }
++// Force off function sections
++// Force on exceptions
++// { dg-options "-fno-function-sections -fexceptions" }
++// PR middle-end/119507
++
++
++inline int comdat() { try { throw 1; } catch (int) { return 1; } return 0; }
++int another_func_with_exception() { try { throw 1; } catch (int) { return 1; } return 0; }
++inline int comdat1() { try { throw 1; } catch (int) { return 1; } return 0; }
++int foo() { return comdat() + comdat1(); }
++
++// Make sure the gcc puts the exception table for both comdat and comdat1 in their own section
++// { dg-final { scan-assembler-times ".section\[\t \]\[^\n\]*.gcc_except_table._Z6comdatv" 1 } }
++// { dg-final { scan-assembler-times ".section\[\t \]\[^\n\]*.gcc_except_table._Z7comdat1v" 1 } }
++// There should be 3 exception tables, 
++// { dg-final { scan-assembler-times ".section\[\t \]\[^\n\]*.gcc_except_table" 3 } }

--- a/debian/rules.patch
+++ b/debian/rules.patch
@@ -567,7 +567,8 @@ debian_patches += \
     loong64/0299-LoongArch-Fix-up-r15-4130 \
     loong64/0300-libphobos-Update-build-scripts-for-LoongArch64 \
     loong64/0301-LoongArch-fix-building-errors \
-    loong64/libsanitizer-Fix-errors-on-LoongArch
+    loong64/libsanitizer-Fix-errors-on-LoongArch \
+    loong64/except-Don-t-use-the-cached-value-of-the-gcc_except_
 
 
 # RISCV backport.


### PR DESCRIPTION
except: Don't use the cached value of the gcc_except_table section for comdat functions [PR119507]

## Summary by Sourcery

Include a Debian patch that prevents using a cached gcc_except_table section for COMDAT functions on LoongArch and update the packaging to apply it

Bug Fixes:
- Fix exception table caching for COMDAT functions on LoongArch

Build:
- Add and apply the new Debian patch in debian/rules

Chores:
- Update debian/changelog to record the new exception handling patch