### PR TITLE
feat: backport riscv-zicbo[mzp] support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+gcc-12 (12.3.0-17deepin16) unstable; urgency=medium
+
+  * feat: add Zicbo[mzp] support for RISC-V which patches backported from
+    latest gcc authored by `ShiYulong <shiyulong@iscas.ac.cn>`.
+
+ -- sisungo <sisungo@icloud.com>  Fri, 19 Sep 2025 19:41:21 +0800
+
 gcc-12 (12.3.0-17deepin15) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/patches/riscv-add-minimal-support-for-zicbo-mzp.diff
+++ b/debian/patches/riscv-add-minimal-support-for-zicbo-mzp.diff
@@ -1,0 +1,53 @@
+--- a/src/gcc/common/config/riscv/riscv-common.cc
++++ b/src/gcc/common/config/riscv/riscv-common.cc
+@@ -165,6 +165,10 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
+   {"zksh",  ISA_SPEC_CLASS_NONE, 1, 0},
+   {"zkt",   ISA_SPEC_CLASS_NONE, 1, 0},
+ 
++  {"zicboz",ISA_SPEC_CLASS_NONE, 1, 0},
++  {"zicbom",ISA_SPEC_CLASS_NONE, 1, 0},
++  {"zicbop",ISA_SPEC_CLASS_NONE, 1, 0},
++
+   {"zk",    ISA_SPEC_CLASS_NONE, 1, 0},
+   {"zkn",   ISA_SPEC_CLASS_NONE, 1, 0},
+   {"zks",   ISA_SPEC_CLASS_NONE, 1, 0},
+@@ -1110,6 +1114,10 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
+   {"zksh",   &gcc_options::x_riscv_zk_subext, MASK_ZKSH},
+   {"zkt",    &gcc_options::x_riscv_zk_subext, MASK_ZKT},
+ 
++  {"zicboz", &gcc_options::x_riscv_zicmo_subext, MASK_ZICBOZ},
++  {"zicbom", &gcc_options::x_riscv_zicmo_subext, MASK_ZICBOM},
++  {"zicbop", &gcc_options::x_riscv_zicmo_subext, MASK_ZICBOP},
++
+   {"zve32x",   &gcc_options::x_target_flags, MASK_VECTOR},
+   {"zve32f",   &gcc_options::x_target_flags, MASK_VECTOR},
+   {"zve64x",   &gcc_options::x_target_flags, MASK_VECTOR},
+--- a/src/gcc/config/riscv/riscv-opts.h
++++ b/src/gcc/config/riscv/riscv-opts.h
+@@ -145,6 +145,14 @@ enum stack_protector_guard {
+ #define TARGET_ZVL32768B ((riscv_zvl_flags & MASK_ZVL32768B) != 0)
+ #define TARGET_ZVL65536B ((riscv_zvl_flags & MASK_ZVL65536B) != 0)
+ 
++#define MASK_ZICBOZ   (1 << 0)
++#define MASK_ZICBOM   (1 << 1)
++#define MASK_ZICBOP   (1 << 2)
++
++#define TARGET_ZICBOZ ((riscv_zicmo_subext & MASK_ZICBOZ) != 0)
++#define TARGET_ZICBOM ((riscv_zicmo_subext & MASK_ZICBOM) != 0)
++#define TARGET_ZICBOP ((riscv_zicmo_subext & MASK_ZICBOP) != 0)
++
+ /* Bit of riscv_zvl_flags will set contintuly, N-1 bit will set if N-bit is
+    set, e.g. MASK_ZVL64B has set then MASK_ZVL32B is set, so we can use
+    popcount to caclulate the minimal VLEN.  */
+--- a/src/gcc/config/riscv/riscv.opt
++++ b/src/gcc/config/riscv/riscv.opt
+@@ -209,6 +209,9 @@ int riscv_vector_elen_flags
+ TargetVariable
+ int riscv_zvl_flags
+ 
++TargetVariable
++int riscv_zicmo_subext
++
+ Enum
+ Name(isa_spec_class) Type(enum riscv_isa_spec_class)
+ Supported ISA specs (for use with the -misa-spec= option):

--- a/debian/patches/riscv-cache-management-operation-instructions-testcases.diff
+++ b/debian/patches/riscv-cache-management-operation-instructions-testcases.diff
@@ -1,0 +1,142 @@
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-1.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-1.c
+new file mode 100644
+index 00000000000..e2ba2183511
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-1.c
+@@ -0,0 +1,21 @@
++/* { dg-do compile } */
++/* { dg-options "-march=rv64gc_zicbom -mabi=lp64" } */
++
++int foo1()
++{
++    return __builtin_riscv_zicbom_cbo_clean();
++}
++
++int foo2()
++{
++    return __builtin_riscv_zicbom_cbo_flush();
++}
++
++int foo3()
++{
++    return __builtin_riscv_zicbom_cbo_inval();
++}
++
++/* { dg-final { scan-assembler-times "cbo.clean" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.flush" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.inval" 1 } } */
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-2.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-2.c
+new file mode 100644
+index 00000000000..a605e8b1bdc
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-2.c
+@@ -0,0 +1,21 @@
++/* { dg-do compile } */
++/* { dg-options "-march=rv32gc_zicbom -mabi=ilp32" } */
++
++int foo1()
++{
++    return __builtin_riscv_zicbom_cbo_clean();
++}
++
++int foo2()
++{
++    return __builtin_riscv_zicbom_cbo_flush();
++}
++
++int foo3()
++{
++    return __builtin_riscv_zicbom_cbo_inval();
++}
++
++/* { dg-final { scan-assembler-times "cbo.clean" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.flush" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.inval" 1 } } */
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-1.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-1.c
+new file mode 100644
+index 00000000000..c5d78c1763d
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-1.c
+@@ -0,0 +1,23 @@
++/* { dg-do compile target { { rv64-*-*}}} */
++/* { dg-options "-march=rv64gc_zicbop -mabi=lp64" } */
++
++void foo (char *p)
++{
++  __builtin_prefetch (p, 0, 0);
++  __builtin_prefetch (p, 0, 1);
++  __builtin_prefetch (p, 0, 2);
++  __builtin_prefetch (p, 0, 3);
++  __builtin_prefetch (p, 1, 0);
++  __builtin_prefetch (p, 1, 1);
++  __builtin_prefetch (p, 1, 2);
++  __builtin_prefetch (p, 1, 3);
++}
++
++int foo1()
++{
++  return __builtin_riscv_zicbop_cbo_prefetchi(1);
++}
++
++/* { dg-final { scan-assembler-times "prefetch.i" 1 } } */
++/* { dg-final { scan-assembler-times "prefetch.r" 4 } } */
++/* { dg-final { scan-assembler-times "prefetch.w" 4 } } */
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-2.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-2.c
+new file mode 100644
+index 00000000000..6576365b39c
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbop-2.c
+@@ -0,0 +1,23 @@
++/* { dg-do compile target { { rv32-*-*}}} */
++/* { dg-options "-march=rv32gc_zicbop -mabi=ilp32" } */
++
++void foo (char *p)
++{
++  __builtin_prefetch (p, 0, 0);
++  __builtin_prefetch (p, 0, 1);
++  __builtin_prefetch (p, 0, 2);
++  __builtin_prefetch (p, 0, 3);
++  __builtin_prefetch (p, 1, 0);
++  __builtin_prefetch (p, 1, 1);
++  __builtin_prefetch (p, 1, 2);
++  __builtin_prefetch (p, 1, 3);
++}
++
++int foo1()
++{
++  return __builtin_riscv_zicbop_cbo_prefetchi(1);
++}
++
++/* { dg-final { scan-assembler-times "prefetch.i" 1 } } */
++/* { dg-final { scan-assembler-times "prefetch.r" 4 } } */
++/* { dg-final { scan-assembler-times "prefetch.w" 4 } } */ 
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-1.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-1.c
+new file mode 100644
+index 00000000000..96c1674ef2d
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-1.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* { dg-options "-march=rv64gc_zicboz -mabi=lp64" } */
++
++int foo1()
++{
++    return __builtin_riscv_zicboz_cbo_zero();
++}
++
++/* { dg-final { scan-assembler-times "cbo.zero" 1 } } */ 
+diff --git a/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-2.c b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-2.c
+new file mode 100644
+index 00000000000..9d99839b1e7
+--- /dev/null
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-2.c
+@@ -0,0 +1,9 @@
++/* { dg-do compile } */
++/* { dg-options "-march=rv32gc_zicboz -mabi=ilp32" } */
++
++int foo1()
++{
++    return __builtin_riscv_zicboz_cbo_zero();
++}
++
++/* { dg-final { scan-assembler-times "cbo.zero" 1 } } */

--- a/debian/patches/riscv-cache-management-operation-instructions.diff
+++ b/debian/patches/riscv-cache-management-operation-instructions.diff
@@ -1,0 +1,155 @@
+--- a/src/gcc/config/riscv/predicates.md
++++ b/src/gcc/config/riscv/predicates.md
+@@ -239,3 +239,7 @@
+ (define_predicate "const63_operand"
+   (and (match_code "const_int")
+        (match_test "INTVAL (op) == 63")))
++
++(define_predicate "imm5_operand"
++  (and (match_code "const_int")
++       (match_test "INTVAL (op) < 5")))
+--- a/src/gcc/config/riscv/riscv-builtins.cc
++++ b/src/gcc/config/riscv/riscv-builtins.cc
+@@ -87,6 +87,18 @@ struct riscv_builtin_description {
+ 
+ AVAIL (hard_float, TARGET_HARD_FLOAT)
+ 
++
++AVAIL (clean32, TARGET_ZICBOM && !TARGET_64BIT)
++AVAIL (clean64, TARGET_ZICBOM && TARGET_64BIT)
++AVAIL (flush32, TARGET_ZICBOM && !TARGET_64BIT)
++AVAIL (flush64, TARGET_ZICBOM && TARGET_64BIT)
++AVAIL (inval32, TARGET_ZICBOM && !TARGET_64BIT)
++AVAIL (inval64, TARGET_ZICBOM && TARGET_64BIT)
++AVAIL (zero32,  TARGET_ZICBOZ && !TARGET_64BIT)
++AVAIL (zero64,  TARGET_ZICBOZ && TARGET_64BIT)
++AVAIL (prefetchi32, TARGET_ZICBOP && !TARGET_64BIT)
++AVAIL (prefetchi64, TARGET_ZICBOP && TARGET_64BIT)
++
+ /* Construct a riscv_builtin_description from the given arguments.
+ 
+    INSN is the name of the associated instruction pattern, without the
+@@ -119,6 +131,8 @@ AVAIL (hard_float, TARGET_HARD_FLOAT)
+ /* Argument types.  */
+ #define RISCV_ATYPE_VOID void_type_node
+ #define RISCV_ATYPE_USI unsigned_intSI_type_node
++#define RISCV_ATYPE_SI intSI_type_node
++#define RISCV_ATYPE_DI intDI_type_node
+ 
+ /* RISCV_FTYPE_ATYPESN takes N RISCV_FTYPES-like type codes and lists
+    their associated RISCV_ATYPEs.  */
+@@ -128,6 +142,8 @@ AVAIL (hard_float, TARGET_HARD_FLOAT)
+   RISCV_ATYPE_##A, RISCV_ATYPE_##B
+ 
+ static const struct riscv_builtin_description riscv_builtins[] = {
++  #include "riscv-cmo.def"
++
+   DIRECT_BUILTIN (frflags, RISCV_USI_FTYPE, hard_float),
+   DIRECT_NO_TARGET_BUILTIN (fsflags, RISCV_VOID_FTYPE_USI, hard_float)
+ };
+diff --git a/src/gcc/config/riscv/riscv-cmo.def b/src/gcc/config/riscv/riscv-cmo.def
+new file mode 100644
+index 00000000000..b30ecf96ec1
+--- /dev/null
++++ b/src/gcc/config/riscv/riscv-cmo.def
+@@ -0,0 +1,17 @@
++// zicbom
++RISCV_BUILTIN (clean_si, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, clean32),
++RISCV_BUILTIN (clean_di, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, clean64),
++
++RISCV_BUILTIN (flush_si, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, flush32),
++RISCV_BUILTIN (flush_di, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, flush64),
++
++RISCV_BUILTIN (inval_si, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, inval32),
++RISCV_BUILTIN (inval_di, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, inval64),
++
++// zicboz
++RISCV_BUILTIN (zero_si, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, zero32),
++RISCV_BUILTIN (zero_di, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, zero64),
++
++// zicbop
++RISCV_BUILTIN (prefetchi_si, "zicbop_cbo_prefetchi", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, prefetchi32),
++RISCV_BUILTIN (prefetchi_di, "zicbop_cbo_prefetchi", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE_DI, prefetchi64),
+--- a/src/gcc/config/riscv/riscv-ftypes.def
++++ b/src/gcc/config/riscv/riscv-ftypes.def
+@@ -28,3 +28,7 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ DEF_RISCV_FTYPE (0, (USI))
+ DEF_RISCV_FTYPE (1, (VOID, USI))
++DEF_RISCV_FTYPE (0, (SI))
++DEF_RISCV_FTYPE (0, (DI))
++DEF_RISCV_FTYPE (1, (SI, SI))
++DEF_RISCV_FTYPE (1, (DI, DI))
+--- a/src/gcc/config/riscv/riscv.md
++++ b/src/gcc/config/riscv/riscv.md
+@@ -71,6 +71,13 @@
+   ;; Stack Smash Protector
+   UNSPEC_SSP_SET
+   UNSPEC_SSP_TEST
++
++  ;; CMO instructions.
++  UNSPECV_CLEAN
++  UNSPECV_FLUSH
++  UNSPECV_INVAL
++  UNSPECV_ZERO
++  UNSPECV_PREI
+ ])
+ 
+ (define_constants
+@@ -2885,6 +2892,56 @@
+   "<load>\t%3, %1\;<load>\t%0, %2\;xor\t%0, %3, %0\;li\t%3, 0"
+   [(set_attr "length" "12")])
+ 
++(define_insn "riscv_clean_<mode>"
++  [(unspec_volatile:X [(match_operand:X 0 "register_operand" "r")]
++    UNSPECV_CLEAN)]
++  "TARGET_ZICBOM"
++  "cbo.clean\t%a0"
++)
++
++(define_insn "riscv_flush_<mode>"
++  [(unspec_volatile:X [(match_operand:X 0 "register_operand" "r")]
++    UNSPECV_FLUSH)]
++  "TARGET_ZICBOM"
++  "cbo.flush\t%a0"
++)
++
++(define_insn "riscv_inval_<mode>"
++  [(unspec_volatile:X [(match_operand:X 0 "register_operand" "r")]
++    UNSPECV_INVAL)]
++  "TARGET_ZICBOM"
++  "cbo.inval\t%a0"
++)
++
++(define_insn "riscv_zero_<mode>"
++  [(unspec_volatile:X [(match_operand:X 0 "register_operand" "r")]
++    UNSPECV_ZERO)]
++  "TARGET_ZICBOZ"
++  "cbo.zero\t%a0"
++)
++
++(define_insn "prefetch"
++  [(prefetch (match_operand 0 "address_operand" "p")
++             (match_operand 1 "imm5_operand" "i")
++             (match_operand 2 "const_int_operand" "n"))]
++  "TARGET_ZICBOP"
++{
++  switch (INTVAL (operands[1]))
++  {
++    case 0: return "prefetch.r\t%a0";
++    case 1: return "prefetch.w\t%a0";
++    default: gcc_unreachable ();
++  }
++})
++
++(define_insn "riscv_prefetchi_<mode>"
++  [(unspec_volatile:X [(match_operand:X 0 "address_operand" "p")
++              (match_operand:X 1 "imm5_operand" "i")]
++              UNSPECV_PREI)]
++  "TARGET_ZICBOP"
++  "prefetch.i\t%a0"
++)
++
+ (include "bitmanip.md")
+ (include "sync.md")
+ (include "peephole.md")

--- a/debian/patches/riscv-fix-a-bug-that-is-the-cmo-builtins.diff
+++ b/debian/patches/riscv-fix-a-bug-that-is-the-cmo-builtins.diff
@@ -1,0 +1,168 @@
+--- a/src/gcc/config/riscv/riscv-builtins.cc
++++ b/src/gcc/config/riscv/riscv-builtins.cc
+@@ -133,6 +133,7 @@ AVAIL (prefetchi64, TARGET_ZICBOP && TARGET_64BIT)
+ #define RISCV_ATYPE_USI unsigned_intSI_type_node
+ #define RISCV_ATYPE_SI intSI_type_node
+ #define RISCV_ATYPE_DI intDI_type_node
++#define RISCV_ATYPE_VOID_PTR ptr_type_node
+ 
+ /* RISCV_FTYPE_ATYPESN takes N RISCV_FTYPES-like type codes and lists
+    their associated RISCV_ATYPEs.  */
+--- a/src/gcc/config/riscv/riscv-cmo.def
++++ b/src/gcc/config/riscv/riscv-cmo.def
+@@ -1,16 +1,16 @@
+ // zicbom
+-RISCV_BUILTIN (clean_si, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, clean32),
+-RISCV_BUILTIN (clean_di, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, clean64),
++RISCV_BUILTIN (clean_si, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, clean32),
++RISCV_BUILTIN (clean_di, "zicbom_cbo_clean", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, clean64),
+ 
+-RISCV_BUILTIN (flush_si, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, flush32),
+-RISCV_BUILTIN (flush_di, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, flush64),
++RISCV_BUILTIN (flush_si, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, flush32),
++RISCV_BUILTIN (flush_di, "zicbom_cbo_flush", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, flush64),
+ 
+-RISCV_BUILTIN (inval_si, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, inval32),
+-RISCV_BUILTIN (inval_di, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, inval64),
++RISCV_BUILTIN (inval_si, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, inval32),
++RISCV_BUILTIN (inval_di, "zicbom_cbo_inval", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, inval64),
+ 
+ // zicboz
+-RISCV_BUILTIN (zero_si, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE, zero32),
+-RISCV_BUILTIN (zero_di, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT, RISCV_DI_FTYPE, zero64),
++RISCV_BUILTIN (zero_si, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, zero32),
++RISCV_BUILTIN (zero_di, "zicboz_cbo_zero", RISCV_BUILTIN_DIRECT_NO_TARGET, RISCV_VOID_FTYPE_VOID_PTR, zero64),
+ 
+ // zicbop
+ RISCV_BUILTIN (prefetchi_si, "zicbop_cbo_prefetchi", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI, prefetchi32),
+--- a/src/gcc/config/riscv/riscv-ftypes.def
++++ b/src/gcc/config/riscv/riscv-ftypes.def
+@@ -28,7 +28,6 @@ along with GCC; see the file COPYING3.  If not see
+ 
+ DEF_RISCV_FTYPE (0, (USI))
+ DEF_RISCV_FTYPE (1, (VOID, USI))
+-DEF_RISCV_FTYPE (0, (SI))
+-DEF_RISCV_FTYPE (0, (DI))
++DEF_RISCV_FTYPE (1, (VOID, VOID_PTR))
+ DEF_RISCV_FTYPE (1, (SI, SI))
+ DEF_RISCV_FTYPE (1, (DI, DI))
+--- a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-1.c
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-1.c
+@@ -1,21 +1,29 @@
+ /* { dg-do compile } */
+ /* { dg-options "-march=rv64gc_zicbom -mabi=lp64" } */
+ 
+-int foo1()
++int var;
++
++void foo1()
+ {
+-    return __builtin_riscv_zicbom_cbo_clean();
++    __builtin_riscv_zicbom_cbo_clean(0);
++    __builtin_riscv_zicbom_cbo_clean(&var);
++    __builtin_riscv_zicbom_cbo_clean((void*)0x111);
+ }
+ 
+-int foo2()
++void foo2()
+ {
+-    return __builtin_riscv_zicbom_cbo_flush();
++    __builtin_riscv_zicbom_cbo_flush(0);
++    __builtin_riscv_zicbom_cbo_flush(&var);
++    __builtin_riscv_zicbom_cbo_flush((void*)0x111);
+ }
+ 
+-int foo3()
++void foo3()
+ {
+-    return __builtin_riscv_zicbom_cbo_inval();
++    __builtin_riscv_zicbom_cbo_inval(0);
++    __builtin_riscv_zicbom_cbo_inval(&var);
++    __builtin_riscv_zicbom_cbo_inval((void*)0x111);
+ }
+ 
+-/* { dg-final { scan-assembler-times "cbo.clean" 1 } } */
+-/* { dg-final { scan-assembler-times "cbo.flush" 1 } } */
+-/* { dg-final { scan-assembler-times "cbo.inval" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.clean" 3 } } */
++/* { dg-final { scan-assembler-times "cbo.flush" 3 } } */
++/* { dg-final { scan-assembler-times "cbo.inval" 3 } } */
+--- a/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-2.c
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicbom-2.c
+@@ -1,21 +1,29 @@
+ /* { dg-do compile } */
+ /* { dg-options "-march=rv32gc_zicbom -mabi=ilp32" } */
+ 
+-int foo1()
++int var;
++
++void foo1()
+ {
+-    return __builtin_riscv_zicbom_cbo_clean();
++    __builtin_riscv_zicbom_cbo_clean(0);
++    __builtin_riscv_zicbom_cbo_clean(&var);
++    __builtin_riscv_zicbom_cbo_clean((void*)0x111);
+ }
+ 
+-int foo2()
++void foo2()
+ {
+-    return __builtin_riscv_zicbom_cbo_flush();
++    __builtin_riscv_zicbom_cbo_flush(0);
++    __builtin_riscv_zicbom_cbo_flush(&var);
++    __builtin_riscv_zicbom_cbo_flush((void*)0x111);
+ }
+ 
+-int foo3()
++void foo3()
+ {
+-    return __builtin_riscv_zicbom_cbo_inval();
++    __builtin_riscv_zicbom_cbo_inval(0);
++    __builtin_riscv_zicbom_cbo_inval(&var);
++    __builtin_riscv_zicbom_cbo_inval((void*)0x111);
+ }
+ 
+-/* { dg-final { scan-assembler-times "cbo.clean" 1 } } */
+-/* { dg-final { scan-assembler-times "cbo.flush" 1 } } */
+-/* { dg-final { scan-assembler-times "cbo.inval" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.clean" 3 } } */
++/* { dg-final { scan-assembler-times "cbo.flush" 3 } } */
++/* { dg-final { scan-assembler-times "cbo.inval" 3 } } */
+--- a/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-1.c
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-1.c
+@@ -1,9 +1,13 @@
+ /* { dg-do compile } */
+ /* { dg-options "-march=rv64gc_zicboz -mabi=lp64" } */
+ 
+-int foo1()
++int var;
++
++void foo1()
+ {
+-    return __builtin_riscv_zicboz_cbo_zero();
++    __builtin_riscv_zicboz_cbo_zero(0);
++    __builtin_riscv_zicboz_cbo_zero(&var);
++    __builtin_riscv_zicboz_cbo_zero((void*)0x121);
+ }
+ 
+-/* { dg-final { scan-assembler-times "cbo.zero" 1 } } */ 
++/* { dg-final { scan-assembler-times "cbo.zero" 3 } } */ 
+--- a/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-2.c
++++ b/src/gcc/testsuite/gcc.target/riscv/cmo-zicboz-2.c
+@@ -1,9 +1,13 @@
+ /* { dg-do compile } */
+ /* { dg-options "-march=rv32gc_zicboz -mabi=ilp32" } */
+ 
+-int foo1()
++int var;
++
++void foo1()
+ {
+-    return __builtin_riscv_zicboz_cbo_zero();
++    __builtin_riscv_zicboz_cbo_zero(0);
++    __builtin_riscv_zicboz_cbo_zero(&var);
++    __builtin_riscv_zicboz_cbo_zero((void*)0x121);
+ }
+ 
+-/* { dg-final { scan-assembler-times "cbo.zero" 1 } } */
++/* { dg-final { scan-assembler-times "cbo.zero" 3 } } */ 

--- a/debian/rules.patch
+++ b/debian/rules.patch
@@ -575,6 +575,10 @@ debian_patches += \
 # RISCV backport.
 debian_patches += riscv64-inline-subword-atomic
 debian_patches += riscv64-atomic-fix
+debian_patches += riscv-add-minimal-support-for-zicbo-mzp
+debian_patches += riscv-cache-management-operation-instructions
+debian_patches += riscv-cache-management-operation-instructions-testcases
+debian_patches += riscv-fix-a-bug-that-is-the-cmo-builtins
 
 # sw64 support
 ifeq ($(DEB_TARGET_ARCH), sw64)


### PR DESCRIPTION
Add Zicbo[mzp] support for RISC-V which patches backported from latest gcc authored by `ShiYulong <shiyulong@iscas.ac.cn>`.

## Summary by Sourcery

Backport RISC-V Zicbo[mzp] extension support into GCC packaging by adding implementation, testcases, and a builtin fix for cache-management operations.

New Features:
- Backport Zicbo[mzp] extension support for RISC-V

Enhancements:
- Implement RISC-V cache-management operation instructions support
- Fix bug in CMO builtins

Build:
- Add Debian packaging patches and update rules for riscv-zicbo-mzp support

Tests:
- Add test cases for RISC-V cache-management operation instructions