### PR TITLE
feat: loong64 sw64 architecture enables PIE by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gcc-12 (12.3.0-17deepin16) unstable; urgency=medium
+
+  * loong64 sw64 architecture enables PIE by default.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 20 Jan 2026 16:36:44 +0800
+
 gcc-12 (12.3.0-17deepin15) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/rules.defs
+++ b/debian/rules.defs
@@ -1490,9 +1490,9 @@ else ifeq ($(distribution),Ubuntu)
   endif
   pie_archs += riscv64
 else ifeq ($(distribution),Deepin)
-  pie_archs = amd64 arm64 i386 riscv64
+  pie_archs = amd64 arm64 i386 riscv64 loong64
 else ifeq ($(distribution),Uos)
-  pie_archs = amd64 arm64 i386 loong64 mips64el riscv64
+  pie_archs = amd64 arm64 i386 loong64 mips64el riscv64 sw64
 endif
 ifneq (,$(filter $(DEB_TARGET_ARCH),$(pie_archs)))
   with_pie := yes


### PR DESCRIPTION
## Summary by Sourcery

Enable position-independent executables (PIE) by default for loong64 and sw64 architectures and update the Debian changelog accordingly.

New Features:
- Default PIE support for loong64 architecture.
- Default PIE support for sw64 architecture.

Documentation:
- Update Debian changelog to document enabling PIE by default on loong64 and sw64.